### PR TITLE
init.lua: correctly restart jobs in matrix workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,3 +274,14 @@ failed:
 ```
 
 </details>
+
+## Status codes
+Job rerunner returns some status code while working on payload from GitHub.
+
+|     | Result     | Meaning                                                                  |
+|-----|------------|--------------------------------------------------------------------------|
+| 204 | No Content | Got empty payload or overall run attempts more or equal to 4. No action. |
+| 200 | OK         | Final job was completed, but no action is required.                      |
+| 201 | Created    | Final job was completed, restarting the workflow.                        |
+| 202 | Accepted   | Recorded the queued or completed jobs and waiting for results.           |
+| 404 | Error      | Job action is 'completed', but there's no previous record about it.      |


### PR DESCRIPTION
 init.lua: correctly restart jobs in matrix workflows

* Count queued and completed jobs to detect the moment
  when all jobs in a workflow are completed.
* Restart workflow if it has completed with one or more failed jobs.
* Reply to webhooks with several HTTP status codes depending
  on the action taken. (See readme.md)
* Log most actions taken in response to webhooks.


Resolves #4 

The example how it works (Jobs matrix [sleep; exit code]):
1. [1, 1]
We send 1 job with exit code 1, what do we see in log:
```log
I> POST /
init.lua:63 E> Empty payload
I> POST /
I> Workflow 3532836386, job other-job (1, 1)#1 is queued
I> Job queued in workflow 3532836386: [3532836386, 1, true]
I> POST /
I> Workflow 3532836386, job other-job (1, 1)#1 is in_progress
I> POST /
I> Workflow 3532836386, job other-job (1, 1)#1 is completed as failure
I> Completed job in workflow 3532836386: [3532836386, 0, false]
I> Api call for re-running 3532836386 run finished with status 201
I> Api response body is {}
I> Rerunning workflow with run_id 3532836386 the current count of jobs in matrix is 0 and fixed equal to false
I> POST /
I> Workflow 3532836386, job other-job (1, 1)#2 is queued
I> Job queued in workflow 3532836386: [3532836386, 1, true]
I> POST /
I> Workflow 3532836386, job other-job (1, 1)#2 is in_progress
I> POST /
I> Workflow 3532836386, job other-job (1, 1)#2 is completed as failure
I> Completed job in workflow 3532836386: [3532836386, 0, false]
I> Api call for re-running 3532836386 run finished with status 201
I> Api response body is {}
I> Rerunning workflow with run_id 3532836386 the current count of jobs in matrix is 0 and fixed equal to false
I> POST /
I> Workflow 3532836386, job other-job (1, 1)#3 is queued
I> Job queued in workflow 3532836386: [3532836386, 1, true]
I> POST /
I> Workflow 3532836386, job other-job (1, 1)#3 is in_progress
I> POST /
I> Workflow 3532836386, job other-job (1, 1)#3 is completed as failure
I> Completed job in workflow 3532836386: [3532836386, 0, false]
I> Api call for re-running 3532836386 run finished with status 201
I> Api response body is {}
I> Rerunning workflow with run_id 3532836386 the current count of jobs in matrix is 0 and fixed equal to false
I> POST /
I> Attempt >= 4, noop
I> POST /
I> Attempt >= 4, noop
```

2. [(30,0), (10, 1), (5, 0)]
```log
POST /
Workflow 3531935294, job other-job (30, 0)#1 is queued
Job queued in workflow 3531935294: [3531935294, 1, true]
POST /
Workflow 3531935294, job other-job (10, 1)#1 is queued
Job queued in workflow 3531935294: [3531935294, 2, true]
POST /
Workflow 3531935294, job other-job (5, 0)#1 is queued
Job queued in workflow 3531935294: [3531935294, 3, true]
POST /
Workflow 3531935294, job other-job (30, 0)#1 is in_progress
POST /
Workflow 3531935294, job other-job (10, 1)#1 is in_progress
POST /
Workflow 3531935294, job other-job (5, 0)#1 is in_progress
POST /
Workflow 3531935294, job other-job (5, 0)#1 is completed as success
Completed job in workflow 3531935294: [3531935294, 2, true]
POST /
Workflow 3531935294, job other-job (30, 0)#1 is completed as success
Completed job in workflow 3531935294: [3531935294, 1, true]
POST /
Workflow 3531935294, job other-job (10, 1)#1 is completed as failure
Completed job in workflow 3531935294: [3531935294, 0, false]
Api call for re-running 3531935294 run finished with status 201
Api response body is {}
Rerunning workflow with run_id 3531935294 the current count of jobs in matrix is 0 and fixed equal to false
POST /
Workflow 3531935294, job other-job (10, 1)#2 is queued
Job queued in workflow 3531935294: [3531935294, 1, true]
POST /
Workflow 3531935294, job other-job (10, 1)#2 is in_progress
POST /
Workflow 3531935294, job other-job (10, 1)#2 is completed as failure
Completed job in workflow 3531935294: [3531935294, 0, false]
Api call for re-running 3531935294 run finished with status 201
Api response body is {}
Rerunning workflow with run_id 3531935294 the current count of jobs in matrix is 0 and fixed equal to false
POST /
Workflow 3531935294, job other-job (10, 1)#3 is queued
Job queued in workflow 3531935294: [3531935294, 1, true]
POST /
Workflow 3531935294, job other-job (10, 1)#3 is in_progress
POST /
Workflow 3531935294, job other-job (10, 1)#3 is completed as failure
Completed job in workflow 3531935294: [3531935294, 0, false]
Api call for re-running 3531935294 run finished with status 201
Api response body is {}
Rerunning workflow with run_id 3531935294 the current count of jobs in matrix is 0 and fixed equal to false
POST /
Attempt >= 4, noop
POST /
Attempt >= 4, noop
POST /
Attempt >= 4, noop
```

3. [1,0]
```log
I> POST /
init.lua:63 E> Empty payload
I> POST /
I> Workflow 3532863309, job other-job (1, 0)#1 is queued
I> Job queued in workflow 3532863309: [3532863309, 1, true]
I> POST /
I> Workflow 3532863309, job other-job (1, 0)#1 is in_progress
I> POST /
I> Workflow 3532863309, job other-job (1, 0)#1 is completed as success
I> Completed job in workflow 3532863309: [3532863309, 0, true]
```