### PR TITLE
init.lua: exclude usernames from retrying

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,10 +278,15 @@ failed:
 ## Status codes
 Job rerunner returns some status code while working on payload from GitHub.
 
-|     | Result     | Meaning                                                                  |
-|-----|------------|--------------------------------------------------------------------------|
-| 204 | No Content | Got empty payload or overall run attempts more or equal to 4. No action. |
-| 200 | OK         | Final job was completed, but no action is required.                      |
-| 201 | Created    | Final job was completed, restarting the workflow.                        |
-| 202 | Accepted   | Recorded the queued or completed jobs and waiting for results.           |
-| 404 | Error      | Job action is 'completed', but there's no previous record about it.      |
+|     | Result     | Meaning                                                                                           |
+|-----|------------|---------------------------------------------------------------------------------------------------|
+| 204 | No Content | Got empty payload, overall run attempts more than allowed, or user in `NO_RETRY_LIST` No action.  |
+| 200 | OK         | Final job was completed, but no action is required.                                               |
+| 201 | Created    | Final job was completed, restarting the workflow.                                                 |
+| 202 | Accepted   | Recorded the queued or completed jobs and waiting for results.                                    |
+| 404 | Error      | Job action is 'completed', but there's no previous record about it.                               |
+
+## Excluding usernames from retrying
+Rerunner will not restart workflows initiated by GitHub users,
+specified in the environment variable `NO_RETRY_LIST`:
+NO_RETRY_LIST=username1,username2


### PR DESCRIPTION
Add functions to get env variable with list of users we restrict to restart workflows and compare it with current payload sender.

Resolves #16

Tests:
NO_RETRY_LIST = 'slavakirichenko,TarantoolBot'
```log
I> POST /
init.lua:74 E> Workflow by  slavakirichenko is not allowed to rerun!
I> GET /
I> POST /
init.lua:74 E> Workflow by  slavakirichenko is not allowed to rerun!
I> POST /
init.lua:74 E> Workflow by  slavakirichenko is not allowed to rerun!
```

NO_RETRY_LIST = ' '
```log
I> POST /
I> Workflow 3572399026, job other-job (1, 0)#1 is queued
I> Job queued in workflow 3572399026: [3572399026, 1, true]
I> POST /
I> Workflow 3572399026, job other-job (1, 0)#1 is in_progress
I> POST /
I> Workflow 3572399026, job other-job (1, 0)#1 is completed as success
I> Job completed in workflow 3572399026: [3572399026, 0, true]
```