### PR TITLE
init: fix attempt to compare string with number

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -88,7 +88,7 @@ function webhook_handler(req)
         log.error('Empty payload')
         return { status = 204 }
     end
-    if payload.workflow_job.run_attempt >= run_attempts then
+    if payload.workflow_job.run_attempt >= tonumber(run_attempts) then
         log.info('Attempt >= '..run_attempts..', no action needed')
         return { status = 204 }
     end


### PR DESCRIPTION
When `RUN_ATTEMPTS` was defined, the value for the `run_attempts` variable was a string and we got the following error: `attempt to compare string with number`.